### PR TITLE
FIX: Discord embed limit issue

### DIFF
--- a/Scripts/bookshelfAPI.py
+++ b/Scripts/bookshelfAPI.py
@@ -584,7 +584,7 @@ async def bookshelf_audio_obj(item_id: str):
     logger.info(f"Media Type:  {mediaType}, Current Time: {currentTime} Seconds")
 
     onlineURL = f"{defaultAPIURL}/items/{item_id}/file/{ino}{tokenInsert}"
-    logger.info(f'attempting to play: {onlineURL}')
+    logger.info(f'attempting to play: f"{defaultAPIURL}/items/{item_id}/file/{ino}')
 
     return onlineURL, currentTime, session_id, bookTitle
 

--- a/Scripts/settings.py
+++ b/Scripts/settings.py
@@ -6,7 +6,7 @@ from dotenv import load_dotenv
 load_dotenv(override=True)
 
 # Version Info
-versionNumber = 'Beta_V1.2.3 HOTFIX'
+versionNumber = 'Beta_V1.2.4 HOTFIX'
 
 COMMAND_COUNT = 0
 

--- a/Scripts/subscription_task.py
+++ b/Scripts/subscription_task.py
@@ -356,6 +356,7 @@ class SubscriptionTask(Extension):
                     await ctx.send("Error activating new book task. Please visit logs for more information. "
                                    "Please make sure to setup the task prior to activation by using command **/setup-tasks**",
                                    ephemeral=True)
+                    return
             else:
                 logger.warning('New book check task was already running, ignoring...')
                 await ctx.send('New book check task is already running, ignoring...', ephemeral=True)


### PR DESCRIPTION
An error would occur when attempting to send more than 10 embeds at once. Although this is unlikely in as the task normally can't scan that fast, I've added some additional contingencies to apply if someone adds more than 10 books at once.Note this can only occur if the new-book-check task is active. 