### PR TITLE
Init messages minor update

### DIFF
--- a/Scripts/settings.py
+++ b/Scripts/settings.py
@@ -6,7 +6,7 @@ from dotenv import load_dotenv
 load_dotenv(override=True)
 
 # Version Info
-versionNumber = 'V1.3.0'
+versionNumber = 'V1.3.1'
 
 COMMAND_COUNT = 0
 
@@ -59,6 +59,9 @@ PLAYBACK_ROLE = os.getenv('PLAYBACK_ROLE', 0)
 
 # Ownership check
 OWNER_ONLY = os.getenv('OWNER_ONLY', True)
+
+# Initial MSG when not in debug mode
+INITIALIZED_MSG = os.getenv('INITIALIZED_MSG', True)
 
 # Used for embed footers
 bookshelf_traveller_footer = f'Powered by Bookshelf Traveller 🕮 | {versionNumber}'

--- a/Scripts/subscription_task.py
+++ b/Scripts/subscription_task.py
@@ -554,6 +554,7 @@ class SubscriptionTask(Extension):
     # Auto Start Task if db is populated
     @listen()
     async def tasks_startup(self, event: Startup):
+        init_msg = bool(os.getenv('INITIALIZED_MSG', False))
         result = search_task_db(
             override_response="Initialized subscription task module, verifying if any tasks are enabled...")
         task_name = "new-book-check"
@@ -572,6 +573,6 @@ class SubscriptionTask(Extension):
                 logger.info(
                     f"Subscription Task db was populated, auto enabling tasks on startup. Refresh rate set to {TASK_FREQUENCY} minutes.")
                 # Debug Stuff
-                if s.DEBUG_MODE != "True":
+                if s.DEBUG_MODE != "True" and s.INITIALIZED_MSG == "True":
                     await owner.send(
                         f"Subscription Task db was populated, auto enabling tasks on startup. Refresh rate set to {TASK_FREQUENCY} minutes.")


### PR DESCRIPTION
Added INITIALIZED_MSG env var. On initial startup is set to true by default. But if bot loses connection and docker isn't restarted (but Bot does restart) this won't spam the owner anymore.