### PR TITLE
set local isFinished state to False during /play

### DIFF
--- a/Scripts/audio.py
+++ b/Scripts/audio.py
@@ -451,6 +451,7 @@ class AudioPlayBack(Extension):
             if startover:
                 logger.info(f"startover flag is true, setting currentTime to 0 instead of {currentTime}")
                 currentTime = 0
+
                 # Also find the first chapter
                 if chapter_array and len(chapter_array) > 0:
                     # Sort chapters by start time
@@ -499,7 +500,7 @@ class AudioPlayBack(Extension):
             self.currentChapter = current_chapter if not startover else self.currentChapter  # Use first chapter if startover
             self.currentChapterTitle = current_chapter.get('title') if not startover else self.currentChapterTitle
             self.chapterArray = chapter_array
-            self.bookFinished = bookFinished
+            self.bookFinished = False  # Force locally to False. If it were True, it would've exited sooner. Startover needs this to be False.
             self.current_channel = ctx.channel_id
             self.play_state = 'playing'
 


### PR DESCRIPTION
There was a regression where starting books over, the chapter logic had the stale state of the book being complete. Causing it to say there's no chapters available even though you were in the first chapter. 

Ideally it would be best practice to ensure ABS state and local state are always in sync, but it would've required making a new method inside the bookshelfAPI, then pulling in that new state after startover is triggered. This is a simple one-line fix that should be sufficient, after a few seconds of playback, ABS resets its own internal isFinished state to False. If we attempt to play a book using startover and it fails to start, the end user would have to again use the startover to try and play the book again. Not the greatest UX, but should be enough and ideally, books never fail to start playing.