### PR TITLE
Enable FFmpeg logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ the server must use an `HTTPS` connection due to a requirement from discord's AP
 | `OPT_IMAGE_URL`    | Optional HTTPS URL for generating cover images and sending them to the discord API. This is primarily if you experience similar issues as mentioned above. | *String*  | **NO**    |
 | `TIMEZONE`         | Default set to `America/Toronto`                                                                                                                           | *String*  | **NO**    |
 | `DEFAULT_PROVIDER` | Experimental, set the default search provider for certain commands.                                                                                        | *String*  | **NO**    |
-| `DEBUG_MODE`       | By default, set to `False`. It enables verbose logs and also disables all notifications.                                                                   | *Boolean*  | **NO**    |
+| `DEBUG_MODE`       | By default, set to `False`. It enables verbose logs and also disables all notifications.                                                                   | *Boolean* | **NO**    |
+| `FFMPEG_DEBUG`     | By default, set to `False`. It creates ffmpege logs inside the appdata folder.                                                                             | *Boolean* | **NO**    |
 
 ## Installation
 **Current Installation method is by docker container, however, you can also run main.py within a project folder.**

--- a/Scripts/audio.py
+++ b/Scripts/audio.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 
 import pytz
 from interactions import *
@@ -131,6 +132,14 @@ class AudioPlayBack(Extension):
             else:
                 actual_start_time = server_current_time
                 logger.info(f"Using server current time: {actual_start_time}")
+
+            if s.FFMPEG_DEBUG:
+                # Create ffmpeg logs directory in appdata
+                ffmpeg_log_dir = os.path.join("db", "ffmpeg")
+                os.makedirs(ffmpeg_log_dir, exist_ok=True)
+    
+                # Set FFmpeg report environment variable. level=24 for warning. 32 for info. 48 for debug.
+                os.environ["FFREPORT"] = f"file={ffmpeg_log_dir}/ffmpeg-%t.log:level=32"
         
             # Build audio object with proper settings
             audio = AudioVolume(audio_obj)

--- a/Scripts/audio.py
+++ b/Scripts/audio.py
@@ -657,24 +657,19 @@ class AudioPlayBack(Extension):
                 return
 
             # Use unified session builder
-            if startover:
-                audio, currentTime, sessionID, bookTitle, bookDuration = await self.build_session(
-                    item_id=book, 
-                    force_restart=True
-                )
+            audio, currentTime, sessionID, bookTitle, bookDuration = await self.build_session(
+                item_id=book, 
+                # if True, start time will be zero
+                force_restart=startover
+            )
 
-                # Also find the first chapter
-                if chapter_array and len(chapter_array) > 0:
-                    # Sort chapters by start time
-                    chapter_array.sort(key=lambda x: float(x.get('start', 0)))
-                    first_chapter = chapter_array[0]
-                    self.currentChapter = first_chapter
-                    self.currentChapterTitle = first_chapter.get('title', 'Chapter 1')
-                    logger.info(f"Setting to first chapter: {self.currentChapterTitle}")
-            else:
-                audio, currentTime, sessionID, bookTitle, bookDuration = await self.build_session(
-                    item_id=book
-                )
+            if startover and chapter_array and len(chapter_array) > 0:
+                # Sort chapters by start time
+                chapter_array.sort(key=lambda x: float(x.get('start', 0)))
+                first_chapter = chapter_array[0]
+                self.currentChapter = first_chapter
+                self.currentChapterTitle = first_chapter.get('title', 'Chapter 1')
+                logger.info(f"Setting to first chapter: {self.currentChapterTitle}")
 
             # Get Book Cover URL
             cover_image = await c.bookshelf_cover_image(book)

--- a/Scripts/settings.py
+++ b/Scripts/settings.py
@@ -34,6 +34,9 @@ TIMEZONE = os.getenv("TIMEZONE", "America/Toronto")
 # Audio Enabled
 AUDIO_ENABLED = str2bool(os.getenv('AUDIO_ENABLED', "True"))
 
+# FFmpeg Debug Logging
+FFMPEG_DEBUG = str2bool(os.getenv('FFMPEG_DEBUG', "False"))
+
 # Multi-user functionality, will remove token from admin and all admin functions
 MULTI_USER = str2bool(os.environ.get('MULTI_USER', "True"))
 
@@ -77,7 +80,8 @@ current_config = {
     "OWNER_ONLY": OWNER_ONLY,
     "TASK_FREQUENCY": TASK_FREQUENCY,
     "AUDIO_ENABLED": AUDIO_ENABLED,
-    "MULTI_USER": MULTI_USER
+    "MULTI_USER": MULTI_USER,
+    "FFMPEG_DEBUG": FFMPEG_DEBUG
 }
 
 # Used for embed footers


### PR DESCRIPTION
Enables FFmpeg logging. As I suspected the FFmpeg command is being ignored, it's directly converting it to pcm_s16le

ffmpeg is seeing -f s16le -ar 48000 -ac 2 -loglevel warning pipe:1 -vn -ar 44100 -acodec aac -re

end result is
Stream #0:0 -> #0:0 (mp3 (mp3float) -> pcm_s16le (native))

Stream #0:0: Audio: pcm_s16le, 48000 Hz, stereo, s16, 1536 kb/s

This PR is based on the build_session branch.