### PR TITLE
update ffmpeg command

### DIFF
--- a/Scripts/audio.py
+++ b/Scripts/audio.py
@@ -143,10 +143,10 @@ class AudioPlayBack(Extension):
         
             # Build audio object with proper settings
             audio = AudioVolume(audio_obj)
-            audio.buffer_seconds = 5
+            audio.buffer_seconds = 1
             audio.locked_stream = True
-            audio.ffmpeg_before_args = f"-ss {actual_start_time}"
-            audio.ffmpeg_args = f"-ar 44100 -acodec aac -re"
+            audio.ffmpeg_before_args = f"-re -ss {actual_start_time}"
+            audio.ffmpeg_args = f""
             audio.bitrate = self.bitrate
             self.volume = audio.volume
         


### PR DESCRIPTION
Adjusted the ffmpeg command to properly use -re, it needs to be placed on the input side to be effective. Because it slows down the read speed of the file to real-time, this caused the buffer to take the full 5 seconds to fill, causing a long delay before playback occurred. Dropping the buffer down to one second seemed to work fine.