### PR TITLE
Add Book Finished indicators and utils.py file

### DIFF
--- a/Scripts/audio.py
+++ b/Scripts/audio.py
@@ -8,6 +8,7 @@ import bookshelfAPI as c
 import settings as s
 from settings import TIMEZONE
 from ui_components import get_playback_rows, create_playback_embed
+from utils import add_progress_indicators
 import logging
 from datetime import datetime, timedelta
 from dotenv import load_dotenv
@@ -1256,6 +1257,11 @@ class AudioPlayBack(Extension):
                     logger.info("No valid recent sessions found, only showing random option")
                     choices = [{"name": "📚 Random Book (Surprise me!)", "value": "random"}]
 
+                # Add progress indicators
+                choices, timed_out = await add_progress_indicators(choices)
+                if timed_out:
+                    logger.warning("Autocomplete progress check timed out for recent sessions")
+
                 await ctx.send(choices=choices)
 
             except Exception as e:
@@ -1346,8 +1352,13 @@ class AudioPlayBack(Extension):
                     if 1 <= len(name) <= 100:
                         choices.append({"name": name, "value": f"{book_id}"})
 
+                # Add progress indicators
+                choices, timed_out = await add_progress_indicators(choices)
+                if timed_out:
+                    logger.warning("Autocomplete progress check timed out for search results")
+
                 await ctx.send(choices=choices)
-                logger.info(choices)
+                logger.debug(f"Sending {len(choices)} autocomplete choices")
 
             except Exception as e:  # NOQA
                 await ctx.send(choices=choices)

--- a/Scripts/bookshelfAPI.py
+++ b/Scripts/bookshelfAPI.py
@@ -414,7 +414,6 @@ async def bookshelf_item_progress(item_id):
         r = await bookshelf_conn(GET=True, endpoint=secondary_url)
         data = r.json()
         title = data['media']['metadata']['title']
-        print(data)
 
         formatted_info = {
             'title': title,

--- a/Scripts/default_commands.py
+++ b/Scripts/default_commands.py
@@ -9,6 +9,7 @@ from datetime import datetime
 # Local file imports
 import bookshelfAPI as c
 import settings
+from utils import add_progress_indicators
 
 # Logger Config
 logger = logging.getLogger("bot")
@@ -530,6 +531,11 @@ class PrimaryCommands(Extension):
                         count += 1
                         choices.append(formatted_item)
 
+                # Add progress indicators
+                choices, timed_out = await add_progress_indicators(choices)
+                if timed_out:
+                    logger.warning("Autocomplete progress check timed out for recent sessions")
+
                 await ctx.send(choices=choices)
 
             except Exception as e:
@@ -555,6 +561,11 @@ class PrimaryCommands(Extension):
                             logger.debug(f'Subtitle found: {subtitle} with length {len(subtitle)}.')
                             if len(subtitle) <= 100:
                                 choices.append({"name": f"{subtitle}", "value": f"{book_id}"})
+
+                # Add progress indicators
+                choices, timed_out = await self.add_progress_indicators(choices)
+                if timed_out:
+                    logger.warning("Autocomplete progress check timed out for search results")
 
                 await ctx.send(choices=choices)
 

--- a/Scripts/utils.py
+++ b/Scripts/utils.py
@@ -1,0 +1,69 @@
+import time
+import logging
+import bookshelfAPI as c
+
+# Logger Config
+logger = logging.getLogger("bot")
+
+
+async def add_progress_indicators(choices, timeout_seconds=2.5):
+    """
+    Add ✅ to finished books in autocomplete choices.
+    Returns (updated_choices, timed_out)
+    """
+    if not choices:
+        return choices, False
+    
+    start_time = time.time()
+    updated_choices = []
+    timed_out = False
+    completed_checks = 0
+    finished_count = 0
+    
+    for i, choice in enumerate(choices):
+        # Check timeout
+        elapsed = time.time() - start_time
+        if elapsed > timeout_seconds:
+            logger.warning(f"Progress check timeout after {elapsed:.2f}s - processed {completed_checks}/{len(choices)} items")
+            timed_out = True
+            updated_choices.extend(choices[i:])  # Add remaining without checkmarks
+            break
+        
+        item_id = choice.get('value')
+        original_name = choice.get('name', '')
+        
+        # Skip special items like "random" or items already with checkmarks
+        if not item_id or item_id == "random" or "📚" in original_name or original_name.startswith('✅'):
+            updated_choices.append(choice)
+            continue
+        
+        try:
+            progress_data = await c.bookshelf_item_progress(item_id)
+            is_finished = progress_data.get('finished', 'False') == 'True'
+            
+            if is_finished:
+                new_name = f"✅ {original_name}"
+    
+                # If too long, truncate to fit
+                if len(new_name) > 100:
+                    # "✅ " = 2 chars, so we have 98 chars left for the name
+                    new_name = f"✅ {original_name[:98]}"
+    
+                choice = {"name": new_name, "value": item_id}
+                finished_count += 1
+            
+            updated_choices.append(choice)
+            completed_checks += 1
+            
+        except Exception as e:
+            logger.debug(f"Error checking progress for {item_id}: {e}")
+            updated_choices.append(choice)
+            completed_checks += 1
+    
+    # Only log if we found finished books or had issues
+    if finished_count > 0:
+        logger.info(f"Found {finished_count} finished books in autocomplete")
+    elif timed_out:
+        pass  # Already logged the timeout above
+    
+    return updated_choices, timed_out


### PR DESCRIPTION
Will add a ✅ to the left of book titles to indicator that they're currently finished. i wanted to change startover from optional to required if the condition were true but apparently you can't modify the commands once they're registered. 

wasn't quite sure where to stick the progress indicator function so i made the utils.py, can move the time stuff and ownership checks there to remove some clutter.

![Screenshot_20250604_221900_Discord](https://github.com/user-attachments/assets/617cc193-7c5b-4256-a36b-718c45e69eed)
