### PR TITLE
Restore Playback Role

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Make sure that you select all intents when setting up your bot and that you have
 ### Known Limitations
 **Podcast playback is currently not supported due to the many differences in pulling the audio sources.**
 
-**Ownership by default will allow you to run all commands, to disable this, use the env variable `OWNER_ONLY`.**
+**Ownership by default will allow only you to control the bot, to disable this, use the env variable `OWNER_ONLY`.**
 
 **When using commands that use images, i.e. `/media_progress` or `/recent_sessions`, 
 the server must use an `HTTPS` connection due to a requirement from discord's API. If not, no image will be generated.**
@@ -38,16 +38,16 @@ the server must use an `HTTPS` connection due to a requirement from discord's AP
 | `DISCORD_TOKEN`    | Discord API Token                                                                                                                                          | *String*  | **YES**   |
 | `bookshelfToken`   | Bookshelf User Token (All user types work, but some will limit your interaction options.)                                                                  | *String*  | **YES**   |
 | `bookshelfURL`     | Bookshelf url with protocol and port, ex: http://localhost:80                                                                                              | *String*  | **YES**   |
-| `PLAYBACK_ROLE`*   | A discord role id, used if you want other users to have access to playback. *NO LONGER SUPPORTED                                                           | *Integer* | **NO**    |
-| `OWNER_ONLY`       | By default set to `True`. Only allow bot owner to use bot.                                                                                                 | *Boolean* | **NO**    |
-| `EPHEMERAL_OUTPUT` | By default set to `True`, this sets all commands to ephemeral (shown only to you). * Note: This has been transitioned to a command, it only affects the default commands module.| *Boolean* | **NO**    |
+| `PLAYBACK_ROLE`    | A discord role id, used if you want other users to have access to playback.                                                                                | *Integer* | **NO**    |
+| `OWNER_ONLY`       | By default set to `True`. Only allow bot owner or role owners (if enabled) to use the bot.                                                                 | *Boolean* | **NO**    |
+| `EPHEMERAL_OUTPUT` | By default set to `True`, this sets all commands to be ephemeral (shown only to you).                                                                      | *Boolean* | **NO**    |
 | `MULTI_USER`       | By default set to `True`, disable this to re-enable admin controls (Conditional on the user logged in.) and to remove the /login and /select options       | *Boolean* | **NO**    |
 | `AUDIO_ENABLED`    | By default set to `True`, disable if you want to remove the ability for audio playback.                                                                    | *Boolean* | **NO**    |
 | `OPT_IMAGE_URL`    | Optional HTTPS URL for generating cover images and sending them to the discord API. This is primarily if you experience similar issues as mentioned above. | *String*  | **NO**    |
 | `TIMEZONE`         | Default set to `America/Toronto`                                                                                                                           | *String*  | **NO**    |
 | `DEFAULT_PROVIDER` | Experimental, set the default search provider for certain commands.                                                                                        | *String*  | **NO**    |
 | `DEBUG_MODE`       | By default, set to `False`. It enables verbose logs and also disables all notifications.                                                                   | *Boolean* | **NO**    |
-| `FFMPEG_DEBUG`     | By default, set to `False`. It creates ffmpege logs inside the appdata folder.                                                                             | *Boolean* | **NO**    |
+| `FFMPEG_DEBUG`     | By default, set to `False`. It creates FFmpeg logs inside the appdata folder.                                                                              | *Boolean* | **NO**    |
 
 ## Installation
 **Current Installation method is by docker container, however, you can also run main.py within a project folder.**
@@ -83,8 +83,6 @@ donkevlar/bookshelf-traveller:latest
 or using docker compose:
 
 ```
-version: '3.8'  # Specify the version of the Compose file format
-
 services:
   bookshelf-traveller:
     image: donkevlar/bookshelf-traveller:latest
@@ -106,9 +104,9 @@ Visit the community applications (CA) store and search for the template name lis
 ### Python Script
 Requirements: **Python 3.10 or above**.
 
-**FFMPEG Must be installed in the project directory and/or in PATH to run audio commands using the script installation method. If this is too difficult, please use the docker instructions above.**
+**FFmpeg must be installed in the project directory and/or in PATH to run audio commands using the script installation method. If this is too difficult, please use the docker instructions above.**
 
-[FFMPEG](https://www.ffmpeg.org/download.html)
+[FFmpeg](https://www.ffmpeg.org/download.html)
 
 you'll also need an '.env' file for loading the above [ENV Variables](https://github.com/donkevlar/Bookshelf-Traveller/blob/master/README.md#environmental-variables)
 
@@ -165,7 +163,7 @@ Here's the list of commands sorted alphabetically:
 | `/play`               | Start a new audio session from server, syncs automatically                                                 | `book_title`                                       |                                                                                                                                                                                                                                               | Autocomplete provides up to the last 10 titles you've listened to. Also, Provides a full embedded UI with playback controls. |
 | `/remove-book`        | Mark a book as downloaded in your wishlist                                                                 |                                                    |                                                                                                                                                                                                                                               |                                                                                                                              |
 | `/recent-sessions`    | Will display ***up to*** 10 recent sessions in a filtered and formatted way.                               |                                                    |                                                                                                                                                                                                                                               |
-| `/recently-added`    | Will display ***up to*** 10 recently added books.                                                           |                                                    |                                                                                                                                                                                                                                               |
+| `/recently-added`     | Will display ***up to*** 10 recently added books.                                                          |                                                    |                                                                                                                                                                                                                                               |
 | `/refresh`            | Refresh play book                                                                                          |                                                    |                                                                                                                                                                                                                                               |
 | `/resume`             | Resume audio                                                                                               |                                                    |                                                                                                                                                                                                                                               |
 | `/select`             | Switch between logged in ABS users                                                                         |                                                    |                                                                                                                                                                                                                                               |

--- a/Scripts/audio.py
+++ b/Scripts/audio.py
@@ -4,11 +4,13 @@ import os
 import pytz
 from interactions import *
 from interactions.api.voice.audio import AudioVolume
+
 import bookshelfAPI as c
 import settings as s
 from settings import TIMEZONE
 from ui_components import get_playback_rows, create_playback_embed
-from utils import add_progress_indicators
+from utils import ownership_check, is_bot_owner, check_session_control, can_control_session, add_progress_indicators
+
 import logging
 from datetime import datetime, timedelta
 from dotenv import load_dotenv
@@ -27,26 +29,6 @@ ownership = s.OWNER_ONLY
 
 # Timezone
 timeZone = pytz.timezone(TIMEZONE)
-
-# Custom check for ownership
-async def ownership_check(ctx: BaseContext):  # NOQA
-
-    logger.info(f'Ownership is currently set to: {ownership}')
-
-    if ownership:
-        logger.info('OWNERSHIP is enabled, verifying if user is authorized.')
-        # Check to see if user is the owner while ownership var is true
-        if ctx.bot.owner.id == ctx.user.id or ctx.user in ctx.bot.owners:
-            logger.info('Verified, executing command!')
-            return True
-        else:
-            logger.warning('User is not an owner!')
-            return False
-
-    else:
-        logger.info('ownership is disabled! skipping!')
-        return True
-
 
 def time_converter(time_sec: int) -> str:
     """
@@ -145,7 +127,13 @@ class AudioPlayBack(Extension):
                 logger.info(f"Using provided start time: {actual_start_time}")
             else:
                 actual_start_time = server_current_time
-                logger.info(f"Using server current time: {actual_start_time}")
+
+                # Log meaningful information about the resume position
+                if server_current_time > 0:
+                    formatted_time = time_converter(int(server_current_time))
+                    logger.info(f"Respecting server progress - resuming at: {formatted_time} ({actual_start_time}s)")
+                else:
+                    logger.info("Starting from beginning - no previous progress found")
 
             if s.FFMPEG_DEBUG:
                 # Create ffmpeg logs directory in appdata
@@ -288,13 +276,17 @@ class AudioPlayBack(Extension):
                 current_chapter, chapter_array, bookFinished, isPodcast = await c.bookshelf_get_current_chapter(
                     self.bookItemID, updatedTime if 'updatedTime' in locals() else None)
 
-                if not isPodcast and current_chapter:
+                if not isPodcast and current_chapter and self.chapterArray and len(self.chapterArray) > 0:
                     # Check if current_chapter has a title key
-                    chapter_title = current_chapter.get('title', 'Unknown Chapter')
+                    chapter_title = current_chapter.get('title', 'Chapter 1')
                     logger.debug(f"Current Chapter Sync: {chapter_title}")
                     self.currentChapter = current_chapter
                     self.currentChapterTitle = chapter_title
-                
+                elif not isPodcast:
+                    # Book has no chapters
+                    self.currentChapter = None
+                    self.currentChapterTitle = 'No Chapters'
+
             except Exception as e:
                 logger.warning(f"Error getting current chapter: {e}")
 
@@ -606,10 +598,19 @@ class AudioPlayBack(Extension):
             return False
 
     # Random Functions ------------------------
+
     # Change Chapter Function
-    async def move_chapter(self, option: str):
-        logger.info(f"executing command /next-chapter")
-        CurrentChapter = self.currentChapter
+    async def move_chapter(self, target_index=None, relative_move=None):
+        """
+        Navigate to a chapter by absolute index or relative movement.
+    
+        Args:
+            target_index: Absolute chapter index (0-based) to navigate to
+            relative_move: Relative movement (+1 for next, -1 for previous)
+    
+        Note: Provide either target_index OR relative_move, not both
+        """
+        logger.info(f"Executing move_chapter with target_index={target_index}, relative_move={relative_move}")
 
         # Check if chapter data exists
         if not self.currentChapter or not self.chapterArray:
@@ -624,168 +625,172 @@ class AudioPlayBack(Extension):
             return
 
         try:
-            # Safely get the current chapter ID
-            currentChapterID = int(CurrentChapter.get('id', 0))
-
-            if option == 'next':
-                nextChapterID = currentChapterID + 1
-                max_chapter_id = max(int(ch.get('id', 0)) for ch in self.chapterArray)
-
-                if nextChapterID > max_chapter_id:
-                    if self.repeat_enabled:
-                        logger.info("Reached final chapter with repeat enabled - restarting book")
-                
-                       # Stop the session update task before restart
-                        if self.session_update.running:
-                            self.session_update.stop()
-                
-                        # Handle restart directly
-                        restart_success = await self.restart_media_from_beginning()
-                        if restart_success:
-                            # Send manual session sync like normal chapter moves do
-                            try:
-                                updatedTime, duration, serverCurrentTime, finished_book = await c.bookshelf_session_update(
-                                    item_id=self.bookItemID, 
-                                    session_id=self.sessionID,
-                                    current_time=updateFrequency - 0.5, 
-                                    next_time=0.0)  # Explicitly sync to beginning
+            # Get current chapter index
+            current_chapter_id = int(self.currentChapter.get('id', 0))
+            current_index = next((i for i, ch in enumerate(self.chapterArray) 
+                                if int(ch.get('id', 0)) == current_chapter_id), 0)
         
-                                self.currentTime = updatedTime  # Should be 0.0
-                                self.nextTime = None
-                            except Exception as e:
-                                logger.error(f"Error syncing restart position: {e}")
-
-                            # Set the chapter info for the UI callback to use
-                            if self.chapterArray and len(self.chapterArray) > 0:
-                                first_chapter = self.chapterArray[0]
-                                self.newChapterTitle = first_chapter.get('title', 'Chapter 1')
-                            else:
-                                self.newChapterTitle = 'Chapter 1'
-
-                            # Restart the session update task
-                            self.session_update.start()
-                            self.found_next_chapter = True
-                            return
-                        else:
-                            logger.error("Restart failed during chapter navigation")
-                            await self.cleanup_session("restart failed")
-                            self.found_next_chapter = False
-                            return
-                    elif self.seriesEnabled and self.currentSeries and not self.isLastBookInSeries:
-                        logger.info("Reached final chapter - moving to next book in series")
-                    
-                        # Stop the session update task before moving to next book
-                        if self.session_update.running:
-                            self.session_update.stop()
-                    
-                        # Move to next book in series
-                        success = await self.move_to_next_book_in_series()
-                        if success:
-                            # Set the chapter info for the UI callback to use
-                            self.newChapterTitle = self.currentChapterTitle
-                            self.found_next_chapter = True
-                            return
-                        else:
-                            logger.error("Failed to move to next book in series")
-                            await self.cleanup_session("series progression failed")
-                            self.found_next_chapter = False
-                            return
-                        
-                    else:
-                        # Normal completion handling - no repeat, no series, or last book in series
-                        logger.info("Skipped past final chapter - marking complete and cleaning up")
-                        await c.bookshelf_mark_book_finished(self.bookItemID, self.sessionID)
-                        await self.cleanup_session("completed via chapter skip")
-                        self.found_next_chapter = False
-                        return
+            # Calculate target index
+            if target_index is not None:
+                next_index = target_index
+            elif relative_move is not None:
+                next_index = current_index + relative_move
             else:
-                nextChapterID = currentChapterID - 1
+                logger.error("Must provide either target_index or relative_move")
+                self.found_next_chapter = False
+                return
 
-            # Check if we're going below Chapter 1 (index 0)
-            if nextChapterID < 0 and option == 'previous':
-                logger.info("Attempting to go before Chapter 1, will restart the book instead")
-                # Just use the first chapter (index 0)
-                nextChapterID = 0
+            # Handle boundary conditions
+            max_index = len(self.chapterArray) - 1
 
-            found_next = False
-            for chapter in self.chapterArray:
-                try:
-                    chapterID = int(chapter.get('id', -1))
-
-                    if nextChapterID == chapterID:
-                        found_next = True
-
-                        # Stop current session update task
+            # Handle going past the end
+            if next_index > max_index:
+                if self.repeat_enabled:
+                    logger.info("Reached final chapter with repeat enabled - restarting book")
+                
+                    # Stop the session update task before restart
+                    if self.session_update.running:
                         self.session_update.stop()
-
-                        # Close current session
-                        await c.bookshelf_close_session(self.sessionID)
-
-                        # Get chapter start time
-                        chapterStart = float(chapter.get('start'))
-                        self.newChapterTitle = chapter.get('title', 'Unknown Chapter')
-
-                        logger.info(f"Selected Chapter: {self.newChapterTitle}, Starting at: {chapterStart}")
-
-                        # Use unified session builder
-                        audio, currentTime, sessionID, bookTitle, bookDuration = await self.build_session(
-                            item_id=self.bookItemID,
-                            start_time=chapterStart
-                        )
-
-                        self.currentChapter = chapter
-                        self.currentChapterTitle = chapter.get('title', 'Unknown Chapter')
-                        logger.info(f"Updated current chapter to: {self.currentChapterTitle}")
-
-                        # Send manual next chapter sync with new session ID
-                        logger.info(f"Updating new session {sessionID} to position {chapterStart}")
+                
+                    # Handle restart directly
+                    restart_success = await self.restart_media_from_beginning()
+                    if restart_success:
+                        # Send manual session sync
                         try:
                             updatedTime, duration, serverCurrentTime, finished_book = await c.bookshelf_session_update(
                                 item_id=self.bookItemID, 
                                 session_id=self.sessionID,
                                 current_time=updateFrequency - 0.5, 
-                                next_time=self.nextTime)
-                    
-                            self.currentTime = updatedTime
-                            logger.info(f"Session update successful: {updatedTime}")
-                        except Exception as e:
-                            logger.error(f"Error updating session: {e}")
-
-                        # Clear nextTime to None
-                        self.nextTime = None
-                        logger.info(f"Verifying session ID is set to {self.sessionID} before starting update task")
-
-                        # Verify chapter information with server
-                        try:
-                            verified_chapter, _, _, _ = await c.bookshelf_get_current_chapter(
-                                item_id=self.bookItemID, current_time=chapterStart)
-                    
-                            if verified_chapter:
-                                verified_title = verified_chapter.get('title')
-                                logger.info(f"Server verified chapter title: {verified_title}")
+                                next_time=0.0)
                         
-                                # If there's a mismatch, update to the server's version
-                                if verified_title != self.currentChapterTitle:
-                                    logger.warning(f"Chapter title mismatch! Local: {self.currentChapterTitle}, Server: {verified_title}")
-                                    self.currentChapter = verified_chapter
-                                    self.currentChapterTitle = verified_title
+                            self.currentTime = updatedTime
+                            self.nextTime = None
                         except Exception as e:
-                            logger.error(f"Error verifying chapter info: {e}")
+                            logger.error(f"Error syncing restart position: {e}")
 
+                        # Set the chapter info for the UI callback to use
+                        if self.chapterArray and len(self.chapterArray) > 0:
+                            first_chapter = self.chapterArray[0]
+                            self.newChapterTitle = first_chapter.get('title', 'Chapter 1')
+                        else:
+                            self.newChapterTitle = 'Chapter 1'
+
+                        # Restart the session update task
                         self.session_update.start()
-
                         self.found_next_chapter = True
                         return
+                    else:
+                        logger.error("Restart failed during chapter navigation")
+                        await self.cleanup_session("restart failed")
+                        self.found_next_chapter = False
+                        return
 
-                except (TypeError, ValueError) as e:
-                    logger.error(f"Error processing chapter ID for chapter: {e}")
-                    continue
-                
-            # If we get here, we didn't find the next chapter
-            if not found_next:
-                logger.warning(f"Could not find chapter with ID {nextChapterID}")
-                self.found_next_chapter = False
-            
+                elif self.seriesEnabled and self.currentSeries and not self.isLastBookInSeries:
+                    logger.info("Reached final chapter - moving to next book in series")                                                                                                                                        # Stop the session update task before moving to next book                                             if self.session_update.running:
+
+                    # Stop the session update task before moving to next book
+                    if self.session_update.running:
+                        self.session_update.stop()
+
+                    # Mark the book as complete
+                    try:
+                        await c.bookshelf_mark_book_finished(self.bookItemID, self.sessionID)
+                        logger.info(f"Successfully marked book {self.bookItemID} as finished before series progression")
+                    except Exception as e:
+                        logger.warning(f"Failed to mark book as finished before series progression: {e}")
+
+                    success = await self.move_to_series_book("next")                                                                                                                              # Move to next book in series                                                                         success = await self.move_to_next_book_in_series()
+                    if success:
+                        # Set the chapter info for the UI callback to use
+                        self.newChapterTitle = self.currentChapterTitle
+                        self.found_next_chapter = True
+
+                        if self.seriesIndex is not None:
+                            self.isFirstBookInSeries = self.seriesIndex == 0
+                            self.isLastBookInSeries = self.seriesIndex == len(self.seriesList) - 1
+                            logger.info(f"Updated series position: book {self.seriesIndex + 1}/{len(self.seriesList)}, first={self.isFirstBookInSeries}, last={self.isLastBookInSeries}")
+
+                        return
+                    else:
+                        logger.error("Failed to move to next book in series")
+                        await self.cleanup_session("series progression failed")
+                        self.found_next_chapter = False
+                        return
+                else:
+                    # Normal completion handling
+                    logger.info("Skipped past final chapter - marking complete and cleaning up")
+                    await c.bookshelf_mark_book_finished(self.bookItemID, self.sessionID)
+                    await self.cleanup_session("completed via chapter skip")
+                    self.found_next_chapter = False
+                    return
+        
+            # Handle going before the beginning
+            if next_index < 0:
+                logger.info("Attempting to go before first chapter, staying at first chapter")
+                next_index = 0
+        
+            # Get target chapter
+            target_chapter = self.chapterArray[next_index]
+        
+            # Stop current session update task
+            self.session_update.stop()
+
+            # Close current session
+            await c.bookshelf_close_session(self.sessionID)
+
+            # Get chapter start time
+            chapter_start = float(target_chapter.get('start'))
+            self.newChapterTitle = target_chapter.get('title', 'Unknown Chapter')
+
+            logger.info(f"Selected Chapter: {self.newChapterTitle}, Starting at: {chapter_start}")
+
+            # Use unified session builder
+            audio, currentTime, sessionID, bookTitle, bookDuration = await self.build_session(
+                item_id=self.bookItemID,
+                start_time=chapter_start
+            )
+
+            self.currentChapter = target_chapter
+            self.currentChapterTitle = target_chapter.get('title', 'Unknown Chapter')
+            logger.info(f"Updated current chapter to: {self.currentChapterTitle}")
+
+            # Send manual session sync with new session ID
+            logger.info(f"Updating new session {sessionID} to position {chapter_start}")
+            try:
+                updatedTime, duration, serverCurrentTime, finished_book = await c.bookshelf_session_update(
+                    item_id=self.bookItemID, 
+                    session_id=self.sessionID,
+                    current_time=updateFrequency - 0.5, 
+                    next_time=self.nextTime)
+    
+                self.currentTime = updatedTime
+                logger.info(f"Session update successful: {updatedTime}")
+            except Exception as e:
+                logger.error(f"Error updating session: {e}")
+
+            # Clear nextTime
+            self.nextTime = None
+
+            # Verify chapter information with server
+            try:
+                verified_chapter, _, _, _ = await c.bookshelf_get_current_chapter(
+                    item_id=self.bookItemID, current_time=chapter_start)
+    
+                if verified_chapter:
+                    verified_title = verified_chapter.get('title')
+                    logger.info(f"Server verified chapter title: {verified_title}")
+        
+                    # If there's a mismatch, update to the server's version
+                    if verified_title != self.currentChapterTitle:
+                        logger.warning(f"Chapter title mismatch! Local: {self.currentChapterTitle}, Server: {verified_title}")
+                        self.currentChapter = verified_chapter
+                        self.currentChapterTitle = verified_title
+            except Exception as e:
+                logger.error(f"Error verifying chapter info: {e}")
+
+            self.session_update.start()
+            self.found_next_chapter = True
+        
         except (TypeError, ValueError) as e:
             logger.error(f"Error in move_chapter: {e}")
             self.found_next_chapter = False
@@ -796,14 +801,14 @@ class AudioPlayBack(Extension):
 
         # Calculate progress percentage and time progressed
         progress_percentage = 0
-        if self.bookDuration and self.bookDuration > 0:
+        if self.bookDuration and self.bookDuration > 0 and self.currentTime is not None:
             safe_current_time = min(self.currentTime, self.bookDuration)
             progress_percentage = (safe_current_time / self.bookDuration) * 100
             progress_percentage = round(progress_percentage, 1)
             progress_percentage = max(0, min(100, progress_percentage))
 
-        formatted_duration = time_converter(self.bookDuration)
-        formatted_current = time_converter(self.currentTime)
+        formatted_duration = time_converter(self.bookDuration) if self.bookDuration else "Unknown"
+        formatted_current = time_converter(self.currentTime) if self.currentTime is not None else "Unknown"
 
         # Prepare series info if available
         series_info = None
@@ -815,16 +820,16 @@ class AudioPlayBack(Extension):
             }
 
         return create_playback_embed(
-            book_title=self.bookTitle,
-            chapter_title=chapter,
+            book_title=self.bookTitle or "Unknown Book",
+            chapter_title=chapter or "Unknown Chapter",
             progress=f"{progress_percentage}%",
             current_time=formatted_current,
             duration=formatted_duration,
-            username=self.username,
-            user_type=self.user_type,
-            cover_image=self.cover_image,
+            username=self.username or "Unknown User",
+            user_type=self.user_type or "user",
+            cover_image=self.cover_image or "",
             color=color,
-            volume=self.volume,
+            volume=self.volume or 0.0,
             timestamp=formatted_time,
             version=s.versionNumber,
             repeat_enabled=self.repeat_enabled,
@@ -841,15 +846,8 @@ class AudioPlayBack(Extension):
     @slash_option(name="startover",
                   description="Start the book from the beginning instead of resuming",
                   opt_type=OptionType.BOOLEAN)
+    @check_session_control("start")
     async def play_audio(self, ctx: SlashContext, book: str, startover=False):
-        # Check for ownership if enabled
-        if ownership:
-            if ctx.author.id not in ctx.bot.owners:
-                logger.warning(f'User {ctx.author} attempted to use /play, and OWNER_ONLY is enabled!')
-                await ctx.send(
-                    content="Ownership enabled and you are not authorized to use this command. Contact bot owner.")
-                return
-
         if not self.bot.is_ready or not ctx.author.voice:
             await ctx.send(content="Bot is not ready or author not in voice channel, please try again later.",
                            ephemeral=True)
@@ -914,6 +912,8 @@ class AudioPlayBack(Extension):
                 force_restart=startover
             )
 
+            self.currentTime = currentTime
+
             await self.setup_series_context(book)
 
             if startover:
@@ -927,6 +927,16 @@ class AudioPlayBack(Extension):
                     # Book has no chapters - clear chapter info
                     self.currentChapter = None
                     self.currentChapterTitle = 'No Chapters'
+            else:
+                # Not starting over - use current chapter data or detect no chapters
+                if current_chapter and chapter_array and len(chapter_array) > 0:
+                    self.currentChapter = current_chapter
+                    self.currentChapterTitle = current_chapter.get('title', 'Chapter 1')
+                else:
+                    # No chapter data available
+                    self.currentChapter = None
+                    self.currentChapterTitle = 'No Chapters'
+
 
             # Get Book Cover URL
             cover_image = await c.bookshelf_cover_image(book)
@@ -949,12 +959,14 @@ class AudioPlayBack(Extension):
 
             # Chapter Vars
             self.isPodcast = isPodcast
-            self.currentChapter = current_chapter if not startover else self.currentChapter  # Use first chapter if startover
-            self.currentChapterTitle = current_chapter.get('title') if not startover else self.currentChapterTitle
             self.chapterArray = chapter_array
             self.bookFinished = False  # Force locally to False. If it were True, it would've exited sooner. Startover needs this to be False.
             self.current_channel = ctx.channel_id
             self.play_state = 'playing'
+
+            if self.currentTime is None:
+                logger.warning(f"currentTime is None after build_session, using 0.0 as fallback")
+                self.currentTime = 0.0
 
             # Create embedded message
             embed_message = self.modified_message(color=ctx.author.accent_color, chapter=self.currentChapterTitle)
@@ -1024,6 +1036,7 @@ class AudioPlayBack(Extension):
 
     # Pause audio, stops tasks, keeps session active.
     @slash_command(name="pause", description="pause audio", dm_permission=False)
+    @check_session_control()
     async def pause_audio(self, ctx):
         if ctx.voice_state:
             await ctx.send("Pausing Audio", ephemeral=True)
@@ -1040,6 +1053,7 @@ class AudioPlayBack(Extension):
 
     # Resume Audio, restarts tasks, session is kept open
     @slash_command(name="resume", description="resume audio", dm_permission=False)
+    @check_session_control()
     async def resume_audio(self, ctx):
         if ctx.voice_state:
             if self.sessionID != "":
@@ -1057,38 +1071,74 @@ class AudioPlayBack(Extension):
             else:
                 await ctx.send(content="Bot or author isn't connected to channel, aborting.", ephemeral=True)
 
-    @check(ownership_check)
-    @slash_command(name="change-chapter", description="play next chapter, if available.", dm_permission=False)
-    @slash_option(name="option", description="Select 'next or 'previous' as options", opt_type=OptionType.STRING,
+    @slash_command(name="change-chapter", description="Navigate to a specific chapter or use next/previous.", dm_permission=False)
+    @slash_option(name="option", description="Select 'next', 'previous', or enter a chapter number", opt_type=OptionType.STRING,
                   autocomplete=True, required=True)
+    @check_session_control()
     async def change_chapter(self, ctx, option: str):
-        if ctx.voice_state:
-            if self.isPodcast:
-                await ctx.send(content="Item type is not book, chapter skip disabled", ephemeral=True)
-                return
-
-            await self.move_chapter(option)
-
-            # Stop auto kill session task
-            if self.auto_kill_session.running:
-                logger.info("Stopping auto kill session backend task.")
-                self.auto_kill_session.stop()
-
-            if self.found_next_chapter:
-                await ctx.send(content=f"Moving to chapter: {self.newChapterTitle}", ephemeral=True)
-                await ctx.voice_state.play(self.audioObj)
-            else:
-                await ctx.send(content=f"Cannot navigate chapters - either the book has no chapter information, is finished, or no chapter was found in the requested direction.",
-                              ephemeral=True)
-
-            # Resetting Variable
-            self.found_next_chapter = False
-        else:
+        if not ctx.voice_state:
             await ctx.send(content="Bot or author isn't connected to channel, aborting.", ephemeral=True)
+            return
 
-    @check(ownership_check)
+        if self.isPodcast:
+            await ctx.send(content="Item type is not book, chapter skip disabled", ephemeral=True)
+            return
+
+        # Check if we have chapter data
+        if not self.currentChapter or not self.chapterArray:
+            await ctx.send(content="This book doesn't have chapter information. Chapter navigation is not available.", 
+                          ephemeral=True)
+            return
+
+        # Handle different option types
+        if option == "next":
+            await self.move_chapter(relative_move=1)
+            operation_desc = "next chapter"
+        elif option == "previous":
+            await self.move_chapter(relative_move=-1)
+            operation_desc = "previous chapter"
+        elif option.isdigit():
+            target_chapter_num = int(option)
+
+            # Validate chapter number (1-based input, convert to 0-based index)
+            if not self.chapterArray or target_chapter_num < 1 or target_chapter_num > len(self.chapterArray):
+                chapter_count = len(self.chapterArray) if self.chapterArray else 0
+                await ctx.send(content=f"Invalid chapter number. This book has {chapter_count} chapters. "
+                                      f"Please enter a number between 1 and {chapter_count}.", 
+                              ephemeral=True)
+                return
+        
+            target_index = target_chapter_num - 1  # Convert to 0-based
+            await self.move_chapter(target_index=target_index)
+            operation_desc = f"Chapter {target_chapter_num}"
+        else:
+            await ctx.send(content="Invalid option. Use 'next', 'previous', or enter a chapter number.", ephemeral=True)
+            return
+
+        # Stop auto kill session task
+        if self.auto_kill_session.running:
+            logger.info("Stopping auto kill session backend task.")
+            self.auto_kill_session.stop()
+
+        # Check if session was cleaned up (book completed)
+        session_was_cleaned_up = not self.sessionID
+
+        if self.found_next_chapter:
+            await ctx.send(content=f"Moving to {operation_desc}: {self.newChapterTitle}", ephemeral=True)
+            await ctx.voice_state.play(self.audioObj)
+        elif session_was_cleaned_up:
+            # Book completed or restarted - this is success, not failure
+            await ctx.send(content="📚 Book completed!", ephemeral=True)
+        else:
+            # Actual navigation failure
+            await ctx.send(content=f"Cannot navigate to {operation_desc}.", ephemeral=True)
+
+        # Reset variable
+        self.found_next_chapter = False
+
     @slash_command(name="volume", description="change the volume for the bot", dm_permission=False)
     @slash_option(name="volume", description="Must be between 1 and 100", required=False, opt_type=OptionType.INTEGER)
+    @check_session_control()
     async def volume_adjuster(self, ctx, volume=0):
         if ctx.voice_state:
             audio = self.audioObj
@@ -1107,6 +1157,7 @@ class AudioPlayBack(Extension):
 
     @slash_command(name="stop", description="Will disconnect from the voice channel and stop audio.",
                    dm_permission=False)
+    @check_session_control()
     async def stop_audio(self, ctx: SlashContext):
         if ctx.voice_state:
             logger.info(f"executing command /stop")
@@ -1115,23 +1166,34 @@ class AudioPlayBack(Extension):
         else:
             await ctx.send(content="Not connected to voice.", ephemeral=True)
 
-    @check(ownership_check)
     @slash_command(name="close-all-sessions",
-                   description="DEBUGGING PURPOSES, close all active sessions. Takes up to 60 seconds.",
+                   description="DEBUGGING PURPOSES, close all active ABS sessions. Takes up to 60 seconds.",
                    dm_permission=False)
     @slash_option(name="max_items", description="max number of items to attempt to close, default=100",
                   opt_type=OptionType.INTEGER)
+    @check(is_bot_owner)
     async def close_active_sessions(self, ctx, max_items=50):
         # Wait for task to complete
-        ctx.defer()
+        await ctx.defer()
+
+        # Add warning if there's active playback
+        if self.activeSessions > 0 and self.sessionID:
+            await ctx.send(
+                "⚠️ **WARNING**: You have active audio playback running. "
+                "This command will close the ABS session, which means:\n"
+                "• Audio will continue playing but won't sync progress\n"
+                "• You should use `/stop` to properly end playback first\n\n"
+                "Proceeding with session cleanup...", 
+                ephemeral=True
+            )
 
         openSessionCount, closedSessionCount, failedSessionCount = await c.bookshelf_close_all_sessions(max_items)
 
         await ctx.send(content=f"Result of attempting to close sessions. success: {closedSessionCount}, "
                                f"failed: {failedSessionCount}, total: {openSessionCount}", ephemeral=True)
 
-    @check(ownership_check)
     @slash_command(name='refresh', description='re-sends your current playback card.')
+    @check_session_control()
     async def refresh_play_card(self, ctx: SlashContext):
         if ctx.voice_state:
             try:
@@ -1147,6 +1209,7 @@ class AudioPlayBack(Extension):
             return await ctx.send("Bot not in voice channel or an error has occured. Please try again later!", ephemeral=True)
 
     @slash_command(name="toggle-series", description="Toggle automatic series progression on/off")
+    @check_session_control()
     async def toggle_series_mode(self, ctx: SlashContext):
         if not ctx.voice_state or self.play_state == 'stopped':
             await ctx.send("No active playback session found.", ephemeral=True)
@@ -1224,27 +1287,17 @@ class AudioPlayBack(Extension):
     
         await ctx.send(embed=embed, ephemeral=True)
 
-    @check(ownership_check)
     @slash_command(name="announce", description="Create a public announcement card for the current playback session")
+    @check_session_control("announce")
     async def announce_playback(self, ctx: SlashContext):
         """
         Creates a public (non-ephemeral) playbook card to invite others to join the listening session.
         Available to bot owner and the user who started the current playback session.
         """
-    
-        # Check if bot owner OR session owner
-        is_bot_owner = ctx.author.id in [ctx.bot.owner.id] + [owner.id for owner in ctx.bot.owners]
-        is_session_owner = self.sessionOwner == ctx.author.username
-    
-        if not (is_bot_owner or is_session_owner):
-            await ctx.send("Only the bot owner or the person who started this playback session can use this command.", ephemeral=True)
-            return
-    
-        # Check if bot is in voice and playing
         if not ctx.voice_state or self.play_state == 'stopped':
             await ctx.send("No active playback session found. Start playing audio first.", ephemeral=True)
             return
-    
+
         # Get current voice channel
         voice_channel = ctx.voice_state.channel
         if not voice_channel:
@@ -1556,8 +1609,44 @@ class AudioPlayBack(Extension):
     @change_chapter.autocomplete("option")
     async def chapter_option_autocomplete(self, ctx: AutocompleteContext):
         choices = [
-            {"name": "next", "value": "next"}, {"name": "previous", "value": "previous"}
+            {"name": "next", "value": "next"}, 
+            {"name": "previous", "value": "previous"}
         ]
+    
+        # Add chapter numbers if we have chapter data
+        if hasattr(self, 'chapterArray') and self.chapterArray:
+            chapter_count = len(self.chapterArray)
+        
+            # Add current chapter info if available
+            current_chapter_info = ""
+            if hasattr(self, 'currentChapter') and self.currentChapter:
+                try:
+                    current_index = next((i for i, ch in enumerate(self.chapterArray) 
+                                        if ch.get('id') == self.currentChapter.get('id')), None)
+                    if current_index is not None:
+                        current_chapter_info = f" (Currently: {current_index + 1})"
+                except:
+                    pass
+        
+            # Add some chapter number options
+            choices.extend([
+                {"name": f"Chapter 1 - {self.chapterArray[0].get('title', 'Unknown')[:30]}", "value": "1"},
+            ])
+        
+            # Add middle chapter if book has many chapters
+            if chapter_count > 10:
+                mid_chapter = chapter_count // 2
+                mid_title = self.chapterArray[mid_chapter - 1].get('title', 'Unknown')[:30]
+                choices.append({"name": f"Chapter {mid_chapter} - {mid_title}", "value": str(mid_chapter)})
+        
+            # Add last chapter
+            if chapter_count > 1:
+                last_title = self.chapterArray[-1].get('title', 'Unknown')[:30]
+                choices.append({"name": f"Chapter {chapter_count} - {last_title}", "value": str(chapter_count)})
+            
+            # Add info about total chapters
+            choices.append({"name": f"📖 This book has {chapter_count} chapters{current_chapter_info}", "value": "info"})
+        
         await ctx.send(choices=choices)
 
     # Series Functions ---------------------------
@@ -1679,18 +1768,52 @@ class AudioPlayBack(Extension):
                 logger.info("Already at the last book in series")
                 return False
             new_index = self.seriesIndex + 1
-            start_time = 0.0  # Always start from beginning for next books
+            target_book_id = self.seriesList[new_index]
+
+            # Check if the target book is finished - if so, start from beginning
+            # Otherwise, let build_session respect the server's current position
+            try:
+                progress_data = await c.bookshelf_item_progress(target_book_id)
+                is_finished = progress_data.get('finished', 'False') == 'True'
+            
+                if is_finished:
+                    start_time = 0.0
+                    logger.info(f"Target book {target_book_id} is finished - starting from beginning")
+                else:
+                    start_time = None  # Let build_session use server's current position
+                    logger.info(f"Target book {target_book_id} not finished - will respect server position")
+                
+            except Exception as e:
+                logger.warning(f"Error checking next book progress, defaulting to server position: {e}")
+                start_time = None  # Let build_session decide
+
         elif direction == "previous":
             if self.seriesIndex <= 0:
                 logger.info("Already at the first book in series")
                 return False
             new_index = self.seriesIndex - 1
-            # Use stored time if this was the previous book, otherwise start from beginning
             target_book_id = self.seriesList[new_index]
-            start_time = 0.0
-            if target_book_id == self.previousBookID and self.previousBookTime:
-                start_time = self.previousBookTime
-                logger.info(f"Resuming previous book at {start_time}s")
+
+            # Check if the target book is finished - if so, start from beginning
+            # Otherwise, let build_session respect the server's current position
+            try:
+                progress_data = await c.bookshelf_item_progress(target_book_id)
+                is_finished = progress_data.get('finished', 'False') == 'True'
+            
+                if is_finished:
+                    start_time = 0.0
+                    logger.info(f"Target book {target_book_id} is finished - starting from beginning")
+                elif target_book_id == self.previousBookID and self.previousBookTime:
+                    start_time = self.previousBookTime
+                    logger.info(f"Resuming previous book at {start_time}s")
+                else:
+                    start_time = 0.0
+                    logger.info(f"No stored progress for previous book - starting from beginning")
+                
+            except Exception as e:
+                logger.warning(f"Error checking book progress, defaulting to beginning: {e}")
+                start_time = 0.0
+
         else:
             logger.error(f"Invalid direction: {direction}")
             return False
@@ -1733,7 +1856,12 @@ class AudioPlayBack(Extension):
             current_chapter, chapter_array, bookFinished, isPodcast = await c.bookshelf_get_current_chapter(target_book_id, start_time)
             self.currentChapter = current_chapter
             self.chapterArray = chapter_array
-            self.currentChapterTitle = current_chapter.get('title', 'Chapter 1' if direction == "next" else 'Unknown Chapter') if current_chapter else ('Chapter 1' if direction == "next" else 'Unknown Chapter')
+
+            if current_chapter and chapter_array and len(chapter_array) > 0:
+                self.currentChapterTitle = current_chapter.get('title', 'Chapter 1')
+            else:
+                self.currentChapterTitle = 'No Chapters'
+
             self.isPodcast = isPodcast
             self.bookFinished = False
         
@@ -1773,6 +1901,10 @@ class AudioPlayBack(Extension):
 
     @component_callback('pause_audio_button')
     async def callback_pause_button(self, ctx: ComponentContext):
+        if not await can_control_session(ctx, self):
+            await ctx.send("You don't have permission to control this session.", ephemeral=True)
+            return
+        
         if ctx.voice_state:
             logger.info('Pausing Playback!')
             self.play_state = 'paused'
@@ -1787,6 +1919,10 @@ class AudioPlayBack(Extension):
 
     @component_callback('play_audio_button')
     async def callback_play_button(self, ctx: ComponentContext):
+        if not await can_control_session(ctx, self):
+            await ctx.send("You don't have permission to control this session.", ephemeral=True)
+            return
+
         if ctx.voice_state:
             logger.info('Resuming Playback!')
             self.play_state = 'playing'
@@ -1804,6 +1940,10 @@ class AudioPlayBack(Extension):
     @component_callback('repeat_button')
     async def callback_repeat_button(self, ctx: ComponentContext):
         """Toggle repeat mode on/off"""
+        if not await can_control_session(ctx, self):
+            await ctx.send("You don't have permission to control this session.", ephemeral=True)
+            return
+
         self.repeat_enabled = not self.repeat_enabled
 
         embed_message = self.modified_message(color=ctx.author.accent_color, chapter=self.currentChapterTitle)
@@ -1811,6 +1951,10 @@ class AudioPlayBack(Extension):
 
     @component_callback('next_chapter_button')
     async def callback_next_chapter_button(self, ctx: ComponentContext):
+        if not await can_control_session(ctx, self):
+            await ctx.send("You don't have permission to control this session.", ephemeral=True)
+            return
+
         if ctx.voice_state:
             logger.info('Moving to next chapter!')
 
@@ -1824,20 +1968,21 @@ class AudioPlayBack(Extension):
             await ctx.defer(edit_origin=True)
             await ctx.edit_origin(components=self.get_current_playback_buttons())
 
-            # Stop current playback first
+            # Stop current playback
             ctx.voice_state.channel.voice_state.player.stop()
 
-            # Find next chapter or restart
-            await self.move_chapter(option='next')
+            # Check if we're on the last chapter before moving
+            current_index = next((i for i, ch in enumerate(self.chapterArray) 
+                                if ch.get('id') == self.currentChapter.get('id')), 0)
+            is_last_chapter = current_index >= len(self.chapterArray) - 1
 
-            # Check if session was cleaned up (book completed without repeat)
-            if not self.sessionID:
-                await ctx.edit_origin(content="📚 Book completed!")
-                return
+            await self.move_chapter(relative_move=1)
 
-            # Check if move_chapter succeeded
+            # Check if session was cleaned up (book completed)
+            session_was_cleaned_up = not self.sessionID
+
             if self.found_next_chapter:
-                # For restart case, newChapterTitle will be set to first chapter
+                # Normal successful navigation or restart
                 chapter_title = self.newChapterTitle if self.newChapterTitle else self.currentChapterTitle
                 embed_message = self.modified_message(color=ctx.author.accent_color, chapter=chapter_title)
 
@@ -1846,17 +1991,22 @@ class AudioPlayBack(Extension):
                     logger.info("Stopping auto kill session backend task.")
                     self.auto_kill_session.stop()
 
-                await ctx.edit(embed=embed_message)
-
+                await ctx.edit(embed=embed_message, components=self.get_current_playback_buttons())
                 await ctx.voice_state.channel.voice_state.play(self.audioObj)
+
+            elif session_was_cleaned_up and is_last_chapter:
+                # Book completed - this is expected, not an error
+                await ctx.edit_origin(content="📚 Book completed!")
+                # Don't show any error message - this is successful completion
+            
             else:
-                # This shouldn't be reached since we check earlier, but just in case
-                await ctx.send(content=f"No next chapter found.", ephemeral=True)
+                # Actual navigation failure (not book completion)
+                await ctx.send(content="Failed to navigate to next chapter.", ephemeral=True)
                 # Restart playback since we stopped it
                 if ctx.voice_state and ctx.voice_state.channel:
                     await ctx.voice_state.channel.voice_state.play(self.audioObj)
 
-            # Resetting Variable
+            # Reset variable
             self.found_next_chapter = False
             self.newChapterTitle = ''  # Clear after use
         else:
@@ -1864,10 +2014,13 @@ class AudioPlayBack(Extension):
 
     @component_callback('previous_chapter_button')
     async def callback_previous_chapter_button(self, ctx: ComponentContext):
+        if not await can_control_session(ctx, self):
+            await ctx.send("You don't have permission to control this session.", ephemeral=True)
+            return
+
         if ctx.voice_state:
             logger.info('Moving to previous chapter!')
 
-            # Check if chapter data exists before attempting navigation
             if not self.currentChapter or not self.chapterArray:
                 logger.warning("No chapter data available for this book. Cannot navigate chapters.")
                 await ctx.send(content="This book doesn't have chapter information. Chapter navigation is not available.", 
@@ -1887,7 +2040,7 @@ class AudioPlayBack(Extension):
                 return
 
             # Find previous chapter
-            await self.move_chapter(option='previous')
+            await self.move_chapter(relative_move=-1)
 
             # Check if move_chapter succeeded before proceeding
             if self.found_next_chapter:
@@ -1898,13 +2051,13 @@ class AudioPlayBack(Extension):
                     logger.info("Stopping auto kill session backend task.")
                     self.auto_kill_session.stop()
 
-                await ctx.edit(embed=embed_message)
+                await ctx.edit(embed=embed_message, components=self.get_current_playback_buttons())
                 ctx.voice_state.channel.voice_state.player.stop()
                 await ctx.voice_state.channel.voice_state.play(self.audioObj)  # NOQA
             else:
-                # This shouldn't be reached since we check earlier, but just in case
-                await ctx.send(content=f"No previous chapter found.", ephemeral=True)
-                # Restart playback since we stopped it
+                # Previous chapter navigation failure is always an actual error
+                # (since going before first chapter just goes to first chapter)
+                await ctx.send(content="Failed to navigate to previous chapter.", ephemeral=True)
                 if ctx.voice_state and ctx.voice_state.channel:
                     await ctx.voice_state.channel.voice_state.play(self.audioObj)
 
@@ -1915,6 +2068,10 @@ class AudioPlayBack(Extension):
 
     @component_callback('stop_audio_button')
     async def callback_stop_button(self, ctx: ComponentContext):
+        if not await can_control_session(ctx, self):
+            await ctx.send("You don't have permission to control this session.", ephemeral=True)
+            return
+
         if ctx.voice_state:
             await ctx.edit_origin()
             await ctx.delete()
@@ -1922,6 +2079,10 @@ class AudioPlayBack(Extension):
 
     @component_callback('next_book_button')
     async def callback_next_book_button(self, ctx: ComponentContext):
+        if not await can_control_session(ctx, self):
+            await ctx.send("You don't have permission to control this session.", ephemeral=True)
+            return
+
         if not ctx.voice_state:
             await ctx.send(content="Bot or author isn't connected to channel, aborting.", ephemeral=True)
             return
@@ -1958,6 +2119,10 @@ class AudioPlayBack(Extension):
 
     @component_callback('previous_book_button')
     async def callback_previous_book_button(self, ctx: ComponentContext):
+        if not await can_control_session(ctx, self):
+            await ctx.send("You don't have permission to control this session.", ephemeral=True)
+            return
+
         if not ctx.voice_state:
             await ctx.send(content="Bot or author isn't connected to channel, aborting.", ephemeral=True)
             return
@@ -1990,6 +2155,10 @@ class AudioPlayBack(Extension):
 
     @component_callback('volume_up_button')
     async def callback_volume_up_button(self, ctx: ComponentContext):
+        if not await can_control_session(ctx, self):
+            await ctx.send("You don't have permission to control this session.", ephemeral=True)
+            return
+
         if ctx.voice_state and ctx.author.voice:
             adjustment = 0.1
             # Update Audio OBJ
@@ -2006,6 +2175,10 @@ class AudioPlayBack(Extension):
 
     @component_callback('volume_down_button')
     async def callback_volume_down_button(self, ctx: ComponentContext):
+        if not await can_control_session(ctx, self):
+            await ctx.send("You don't have permission to control this session.", ephemeral=True)
+            return
+
         if ctx.voice_state and ctx.author.voice:
             adjustment = 0.1
 
@@ -2029,6 +2202,10 @@ class AudioPlayBack(Extension):
         - seek_amount: Number of seconds to seek (positive value)
         - is_forward: True for forward seeking, False for rewinding
         """
+        if not await can_control_session(ctx, self):
+            await ctx.send("You don't have permission to control this session.", ephemeral=True)
+            return
+
         if not ctx.voice_state:
             await ctx.send(content="Bot or author isn't connected to channel, aborting.", ephemeral=True)
             return

--- a/Scripts/default_commands.py
+++ b/Scripts/default_commands.py
@@ -9,7 +9,7 @@ from datetime import datetime
 # Local file imports
 import bookshelfAPI as c
 import settings
-from utils import ownership_check, add_progress_indicators
+from utils import ownership_check, is_bot_owner, add_progress_indicators
 
 # Logger Config
 logger = logging.getLogger("bot")
@@ -40,7 +40,8 @@ class PrimaryCommands(Extension):
     # Slash Commands ----------------------------------------------------
     #
 
-    # Pings the server, can ping other servers, why? IDK, cause why not.
+    # Pings the server
+    @check(is_bot_owner)
     @slash_command(name="ping", description="Latency of the discord bot server to the discord central shard. Default Command.")
     async def ping(self, ctx: SlashContext):
         latency = self.bot.latency
@@ -48,7 +49,7 @@ class PrimaryCommands(Extension):
             message = "Latency data not available yet. Please try again in a few seconds."
         else:
             message = f'Discord BOT Server Latency: {round(latency * 1000)} ms'
-        await ctx.send(message, ephemeral=self.ephemeral_output)
+        await ctx.send(message, ephemeral=True)
         logger.debug(f' Successfully sent command: ping')
 
     # Self-explanatory, pulls all a library's items


### PR DESCRIPTION
Restores playback roles and touched up the permissions a little, made ping bot owner only.

If OWNER_ONLY is false, anyone can start a session, but the public users are in a first come, first serve basis, if someone else is playing a session, they cant touch it.

If someone is added under the role, they become a manager, they can control any session, even the bot owners stream.

Roles will work with owner_only being true. It makes the naming a bit of a misnomer but dont have anything better and dont want to break backwards compatibility. 