### PR TITLE
use returned currentTime instead of initializing start_time

### DIFF
--- a/Scripts/audio.py
+++ b/Scripts/audio.py
@@ -1865,7 +1865,7 @@ class AudioPlayBack(Extension):
         
             # Update audio state
             self.audioObj = audio
-            self.currentTime = start_time
+            self.currentTime = currentTime
             self.bookItemID = target_book_id
             self.bookTitle = bookTitle
             self.bookDuration = bookDuration


### PR DESCRIPTION
fixes the Unknown current time when transitioning from one book to the next book in series mode.