### PR TITLE
Add Enable Series mode button

### DIFF
--- a/Scripts/audio.py
+++ b/Scripts/audio.py
@@ -463,7 +463,6 @@ class AudioPlayBack(Extension):
             self.nextTime = None
 
             # Reset series context
-            self.seriesEnabled = True  # Reset to default
             self.seriesList = []
             self.seriesIndex = None
             self.previousBookID = None
@@ -1916,7 +1915,8 @@ class AudioPlayBack(Extension):
             is_podcast=self.isPodcast,
             is_series=is_series,
             is_first_book=self.isFirstBookInSeries,
-            is_last_book=self.isLastBookInSeries
+            is_last_book=self.isLastBookInSeries,
+            series_enabled=self.seriesEnabled
         )
 
     @component_callback('pause_audio_button')
@@ -2140,6 +2140,19 @@ class AudioPlayBack(Extension):
             await ctx.voice_state.channel.voice_state.play(self.audioObj)
         else:
             await ctx.send(content="Failed to move to previous book in series.", ephemeral=True)
+
+    @component_callback('toggle_series_button')
+    async def callback_toggle_series_button(self, ctx: ComponentContext):
+        """Toggle series auto-progression mode"""
+        self.seriesEnabled = not self.seriesEnabled
+        status = "enabled" if self.seriesEnabled else "disabled"
+    
+        # Update the embed and buttons
+        embed_message = self.modified_message(color=ctx.author.accent_color, chapter=self.currentChapterTitle)
+        await ctx.edit_origin(embed=embed_message, components=self.get_current_playback_buttons())
+    
+        # Send a brief status message
+        await ctx.send(f"Series auto-progression {status}.", ephemeral=True)
 
     @component_callback('volume_up_button')
     async def callback_volume_up_button(self, ctx: ComponentContext):

--- a/Scripts/ui_components.py
+++ b/Scripts/ui_components.py
@@ -3,7 +3,7 @@ from interactions import ActionRow, Button, ButtonStyle, Embed
 # --- Playback Rows ---
 
 def get_playback_rows(play_state="playing", repeat_enabled=False, is_podcast=False,
-                     has_chapters=True, is_series=False, is_first_book=False, is_last_book=False):
+                     has_chapters=True, is_series=False, is_first_book=False, is_last_book=False, series_enabled=True):
     """Build dynamic playback control rows based on state"""
     is_paused = play_state == "paused"
     rows = []
@@ -60,6 +60,11 @@ def get_playback_rows(play_state="playing", repeat_enabled=False, is_podcast=Fal
                 style=ButtonStyle.PRIMARY, 
                 label="Prior Book", 
                 custom_id="previous_book_button"
+            ),
+            Button(
+                style=ButtonStyle.SUCCESS if series_enabled else ButtonStyle.SECONDARY,
+                label="Series",
+                custom_id="toggle_series_button"
             ),
             Button(
                 disabled=is_last_book, 


### PR DESCRIPTION
Add Series Button. Series Mode no longer resets on cleanup. If you disable series mode, it will remain false until you restore it or the bot restarts. 

![Screenshot_20250608_083751_Discord](https://github.com/user-attachments/assets/d0d513ec-30ea-47db-ad87-11c2e94dc0fe)
